### PR TITLE
Fix maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
                     <argLine>-Xms512m -Xmx1500m</argLine>
                     <parallel>methods</parallel>
                     <forkMode>pertest</forkMode>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Tests in circleci are breaking with:
`Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter`

https://maven.apache.org/surefire/maven-surefire-plugin/examples/class-loading.html